### PR TITLE
feat: shift course form error handling to @edx/paragon styles

### DIFF
--- a/src/components/CreateCoursePage/CreateCourseForm.jsx
+++ b/src/components/CreateCoursePage/CreateCourseForm.jsx
@@ -14,6 +14,7 @@ import PriceList from '../PriceList';
 import {
   DATE_INPUT_PATTERN,
 } from '../../data/constants';
+
 import {
   endDateHelp, runTypeHelp, pacingHelp, startDateHelp, titleHelp, typeHelp, keyHelp,
 } from '../../helpText';
@@ -21,6 +22,10 @@ import DateTimeField from '../DateTimeField';
 import {
   isSafari, localTimeZone, getDateWithDashes, getOptionsData, parseCourseTypeOptions, parseOptions,
 } from '../../utils';
+
+import {
+  handleCourseCreateFail, requiredValidate, dateTimeValidate, courseRunKeyValidate,
+} from '../../utils/validation';
 
 class BaseCreateCourseForm extends React.Component {
   constructor(props) {
@@ -101,17 +106,20 @@ class BaseCreateCourseForm extends React.Component {
       <div className="create-course-form">
         <h2>Create New Course</h2>
         <hr />
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} noValidate>
           <Field
             name="org"
             component={RenderSelectField}
+            props={{ name: 'org' }}
             options={this.processOrganizations(organizations)}
             label={<FieldLabel text="Organization" required />}
             required
+            validate={requiredValidate}
           />
           <Field
             name="title"
             component={RenderInputTextField}
+            props={{ name: 'title' }}
             type="text"
             label={(
               <FieldLabel
@@ -122,10 +130,12 @@ class BaseCreateCourseForm extends React.Component {
               />
             )}
             required
+            validate={requiredValidate}
           />
           <Field
             name="number"
             component={RenderInputTextField}
+            props={{ name: 'number' }}
             type="text"
             label={(
               <FieldLabel
@@ -161,11 +171,12 @@ class BaseCreateCourseForm extends React.Component {
                 )}
               />
             )}
-            required
+            validate={requiredValidate}
           />
           <Field
             name="type"
             component={RenderSelectField}
+            props={{ name: 'type' }}
             options={courseTypeOptions}
             label={(
               <FieldLabel
@@ -175,7 +186,7 @@ class BaseCreateCourseForm extends React.Component {
                 helpText={typeHelp}
               />
             )}
-            required
+            validate={requiredValidate}
           />
           <PriceList
             priceLabels={currentFormValues.type ? priceLabels[currentFormValues.type] : {}}
@@ -188,6 +199,7 @@ class BaseCreateCourseForm extends React.Component {
             <Field
               name="courseRunKey"
               component={RenderInputTextField}
+              props={{ name: 'courseRunKey' }}
               type="text"
               pattern="[a-zA-Z0-9-]+"
               label={(
@@ -198,6 +210,7 @@ class BaseCreateCourseForm extends React.Component {
                   optional
                 />
               )}
+              validate={courseRunKeyValidate}
             />
             )}
           {/* TODO this should be refactored when paragon supports safari */}
@@ -209,6 +222,7 @@ class BaseCreateCourseForm extends React.Component {
                   name="start"
                   type="text"
                   component={DateTimeField}
+                  props={{ name: 'start' }}
                   dateLabel="Start date"
                   timeLabel={`Start time (${localTimeZone})`}
                   helpText={startDateHelp}
@@ -216,11 +230,13 @@ class BaseCreateCourseForm extends React.Component {
                   maxLength="10"
                   pattern={DATE_INPUT_PATTERN}
                   placeholder="yyyy/mm/dd"
+                  validate={[requiredValidate, dateTimeValidate]}
                 />
                 <Field
                   name="end"
                   type="text"
                   component={DateTimeField}
+                  props={{ name: 'end' }}
                   dateLabel="End date"
                   timeLabel={`End time (${localTimeZone})`}
                   helpText={endDateHelp}
@@ -228,6 +244,7 @@ class BaseCreateCourseForm extends React.Component {
                   maxLength="10"
                   pattern={DATE_INPUT_PATTERN}
                   placeholder="yyyy/mm/dd"
+                  validate={[requiredValidate, dateTimeValidate]}
                 />
               </div>
             )
@@ -238,27 +255,32 @@ class BaseCreateCourseForm extends React.Component {
                   name="start"
                   type="date"
                   component={DateTimeField}
+                  props={{ name: 'start' }}
                   dateLabel="Start date"
                   timeLabel={`Start time (${localTimeZone})`}
                   helpText={startDateHelp}
                   required
                   minDate={getDateWithDashes(moment())}
+                  validate={[requiredValidate, dateTimeValidate]}
                 />
                 <Field
                   name="end"
                   type="date"
                   component={DateTimeField}
+                  props={{ name: 'end' }}
                   dateLabel="End date"
                   timeLabel={`End time (${localTimeZone})`}
                   helpText={endDateHelp}
                   required
                   minDate={getDateWithDashes(moment(currentFormValues.start).add(1, 'd') || moment())}
+                  validate={[requiredValidate, dateTimeValidate]}
                 />
               </div>
             )}
           <Field
             name="run_type"
             component={RenderSelectField}
+            props={{ name: 'run_type' }}
             options={currentFormValues.type ? courseRunTypeOptions[currentFormValues.type] : [{ label: 'Select Course enrollment track first', value: '' }]}
             label={(
               <FieldLabel
@@ -269,11 +291,13 @@ class BaseCreateCourseForm extends React.Component {
               />
             )}
             required
+            validate={requiredValidate}
           />
           <Field
             name="pacing_type"
             type="text"
             component={RenderSelectField}
+            props={{ name: 'pacing_type' }}
             options={pacingTypeOptions}
             label={(
               <FieldLabel
@@ -353,5 +377,6 @@ BaseCreateCourseForm.propTypes = {
 
 export default reduxForm({
   form: 'create-course-form',
+  onSubmitFail: handleCourseCreateFail,
 })(BaseCreateCourseForm);
 export { BaseCreateCourseForm };

--- a/src/components/CreateCoursePage/__snapshots__/CreateCourseForm.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCourseForm.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
   </h2>
   <hr />
   <form
+    noValidate={true}
     onSubmit={[Function]}
   >
     <Field
@@ -43,7 +44,13 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "org",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -96,8 +103,14 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
         />
       }
       name="title"
+      props={
+        Object {
+          "name": "title",
+        }
+      }
       required={true}
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -144,8 +157,13 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
         />
       }
       name="number"
-      required={true}
+      props={
+        Object {
+          "name": "number",
+        }
+      }
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -203,7 +221,12 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
           },
         ]
       }
-      required={true}
+      props={
+        Object {
+          "name": "type",
+        }
+      }
+      validate={[Function]}
     />
     <PriceList
       disabled={false}
@@ -246,9 +269,20 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
         name="start"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "start",
+          }
+        }
         required={true}
         timeLabel="Start time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
       <Field
         component={[Function]}
@@ -267,9 +301,20 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
         name="end"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "end",
+          }
+        }
         required={true}
         timeLabel="End time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
     </div>
     <Field
@@ -317,7 +362,13 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "run_type",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -352,6 +403,11 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             "value": "self_paced",
           },
         ]
+      }
+      props={
+        Object {
+          "name": "pacing_type",
+        }
       }
       type="text"
     />
@@ -396,6 +452,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
   </h2>
   <hr />
   <form
+    noValidate={true}
     onSubmit={[Function]}
   >
     <Field
@@ -430,7 +487,13 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "org",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -483,8 +546,14 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
         />
       }
       name="title"
+      props={
+        Object {
+          "name": "title",
+        }
+      }
       required={true}
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -531,8 +600,13 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
         />
       }
       name="number"
-      required={true}
+      props={
+        Object {
+          "name": "number",
+        }
+      }
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -590,7 +664,12 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
           },
         ]
       }
-      required={true}
+      props={
+        Object {
+          "name": "type",
+        }
+      }
+      validate={[Function]}
     />
     <PriceList
       disabled={false}
@@ -633,9 +712,20 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
         name="start"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "start",
+          }
+        }
         required={true}
         timeLabel="Start time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
       <Field
         component={[Function]}
@@ -654,9 +744,20 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
         name="end"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "end",
+          }
+        }
         required={true}
         timeLabel="End time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
     </div>
     <Field
@@ -704,7 +805,13 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "run_type",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -739,6 +846,11 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             "value": "self_paced",
           },
         ]
+      }
+      props={
+        Object {
+          "name": "pacing_type",
+        }
       }
       type="text"
     />
@@ -783,6 +895,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
   </h2>
   <hr />
   <form
+    noValidate={true}
     onSubmit={[Function]}
   >
     <Field
@@ -817,7 +930,13 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "org",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -870,8 +989,14 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
         />
       }
       name="title"
+      props={
+        Object {
+          "name": "title",
+        }
+      }
       required={true}
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -918,8 +1043,13 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
         />
       }
       name="number"
-      required={true}
+      props={
+        Object {
+          "name": "number",
+        }
+      }
       type="text"
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -977,7 +1107,12 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
           },
         ]
       }
-      required={true}
+      props={
+        Object {
+          "name": "type",
+        }
+      }
+      validate={[Function]}
     />
     <PriceList
       disabled={false}
@@ -1016,9 +1151,20 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
         name="start"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "start",
+          }
+        }
         required={true}
         timeLabel="Start time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
       <Field
         component={[Function]}
@@ -1037,9 +1183,20 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
         name="end"
         pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
         placeholder="yyyy/mm/dd"
+        props={
+          Object {
+            "name": "end",
+          }
+        }
         required={true}
         timeLabel="End time (GMT)"
         type="text"
+        validate={
+          Array [
+            [Function],
+            [Function],
+          ]
+        }
       />
     </div>
     <Field
@@ -1079,7 +1236,13 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
           },
         ]
       }
+      props={
+        Object {
+          "name": "run_type",
+        }
+      }
       required={true}
+      validate={[Function]}
     />
     <Field
       component={[Function]}
@@ -1114,6 +1277,11 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             "value": "self_paced",
           },
         ]
+      }
+      props={
+        Object {
+          "name": "pacing_type",
+        }
       }
       type="text"
     />

--- a/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
@@ -35,7 +35,9 @@ exports[`CreateCoursePage renders html correctly 1`] = `
         id="create-course-form"
         initialValues={Object {}}
         keepDirtyOnReinitialize={false}
+        onChange={[Function]}
         onSubmit={[Function]}
+        onSubmitFail={[Function]}
         organizations={Array []}
         persistentSubmitErrors={false}
         pure={true}
@@ -105,43 +107,6 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
     wide={false}
   >
     <div>
-      <ReduxForm
-        courseOptions={Object {}}
-        courseRunOptions={Object {}}
-        currentFormValues={Object {}}
-        destroyOnUnmount={true}
-        enableReinitialize={false}
-        forceUnregisterOnUnmount={false}
-        form="create-course-form"
-        getFormState={[Function]}
-        id="create-course-form"
-        initialValues={Object {}}
-        isCreating={false}
-        keepDirtyOnReinitialize={false}
-        onSubmit={[Function]}
-        organizations={
-          Array [
-            Object {
-              "key": "edx",
-              "name": "edX",
-            },
-            Object {
-              "key": "edx2",
-              "name": "edX2",
-            },
-          ]
-        }
-        persistentSubmitErrors={false}
-        pure={true}
-        shouldAsyncValidate={[Function]}
-        shouldError={[Function]}
-        shouldValidate={[Function]}
-        shouldWarn={[Function]}
-        submitAsSideEffect={false}
-        touchOnBlur={true}
-        touchOnChange={false}
-        updateUnregisteredFields={false}
-      />
       <ForwardRef
         dismissible={false}
         id="create-error"
@@ -167,6 +132,45 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
         Fail
         <br />
       </ForwardRef>
+      <ReduxForm
+        courseOptions={Object {}}
+        courseRunOptions={Object {}}
+        currentFormValues={Object {}}
+        destroyOnUnmount={true}
+        enableReinitialize={false}
+        forceUnregisterOnUnmount={false}
+        form="create-course-form"
+        getFormState={[Function]}
+        id="create-course-form"
+        initialValues={Object {}}
+        isCreating={false}
+        keepDirtyOnReinitialize={false}
+        onChange={[Function]}
+        onSubmit={[Function]}
+        onSubmitFail={[Function]}
+        organizations={
+          Array [
+            Object {
+              "key": "edx",
+              "name": "edX",
+            },
+            Object {
+              "key": "edx2",
+              "name": "edX2",
+            },
+          ]
+        }
+        persistentSubmitErrors={false}
+        pure={true}
+        shouldAsyncValidate={[Function]}
+        shouldError={[Function]}
+        shouldValidate={[Function]}
+        shouldWarn={[Function]}
+        submitAsSideEffect={false}
+        touchOnBlur={true}
+        touchOnChange={false}
+        updateUnregisteredFields={false}
+      />
     </div>
   </PageContainer>
 </Fragment>
@@ -208,7 +212,9 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
         initialValues={Object {}}
         isCreating={true}
         keepDirtyOnReinitialize={false}
+        onChange={[Function]}
         onSubmit={[Function]}
+        onSubmitFail={[Function]}
         organizations={
           Array [
             Object {
@@ -273,7 +279,9 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
         initialValues={Object {}}
         isCreating={false}
         keepDirtyOnReinitialize={false}
+        onChange={[Function]}
         onSubmit={[Function]}
+        onSubmitFail={[Function]}
         organizations={
           Array [
             Object {
@@ -366,43 +374,6 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
     wide={false}
   >
     <div>
-      <ReduxForm
-        courseOptions={Object {}}
-        courseRunOptions={Object {}}
-        currentFormValues={Object {}}
-        destroyOnUnmount={true}
-        enableReinitialize={false}
-        forceUnregisterOnUnmount={false}
-        form="create-course-form"
-        getFormState={[Function]}
-        id="create-course-form"
-        initialValues={Object {}}
-        isCreating={false}
-        keepDirtyOnReinitialize={false}
-        onSubmit={[Function]}
-        organizations={
-          Array [
-            Object {
-              "key": "edx",
-              "name": "edX",
-            },
-            Object {
-              "key": "edx2",
-              "name": "edX2",
-            },
-          ]
-        }
-        persistentSubmitErrors={false}
-        pure={true}
-        shouldAsyncValidate={[Function]}
-        shouldError={[Function]}
-        shouldValidate={[Function]}
-        shouldWarn={[Function]}
-        submitAsSideEffect={false}
-        touchOnBlur={true}
-        touchOnChange={false}
-        updateUnregisteredFields={false}
-      />
       <ForwardRef
         dismissible={false}
         id="create-error"
@@ -428,6 +399,45 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
         Fail
         <br />
       </ForwardRef>
+      <ReduxForm
+        courseOptions={Object {}}
+        courseRunOptions={Object {}}
+        currentFormValues={Object {}}
+        destroyOnUnmount={true}
+        enableReinitialize={false}
+        forceUnregisterOnUnmount={false}
+        form="create-course-form"
+        getFormState={[Function]}
+        id="create-course-form"
+        initialValues={Object {}}
+        isCreating={false}
+        keepDirtyOnReinitialize={false}
+        onChange={[Function]}
+        onSubmit={[Function]}
+        onSubmitFail={[Function]}
+        organizations={
+          Array [
+            Object {
+              "key": "edx",
+              "name": "edX",
+            },
+            Object {
+              "key": "edx2",
+              "name": "edX2",
+            },
+          ]
+        }
+        persistentSubmitErrors={false}
+        pure={true}
+        shouldAsyncValidate={[Function]}
+        shouldError={[Function]}
+        shouldValidate={[Function]}
+        shouldWarn={[Function]}
+        submitAsSideEffect={false}
+        touchOnBlur={true}
+        touchOnChange={false}
+        updateUnregisteredFields={false}
+      />
     </div>
   </PageContainer>
 </Fragment>
@@ -469,7 +479,9 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
         initialValues={Object {}}
         isCreating={false}
         keepDirtyOnReinitialize={false}
+        onChange={[Function]}
         onSubmit={[Function]}
+        onSubmitFail={[Function]}
         organizations={
           Array [
             Object {

--- a/src/components/CreateCoursePage/index.jsx
+++ b/src/components/CreateCoursePage/index.jsx
@@ -35,6 +35,13 @@ class CreateCoursePage extends React.Component {
     this.setStartedFetching();
   }
 
+  componentDidUpdate(prevProps) {
+    // check if errors on form submission and scroll to them
+    if (this.props.courseInfo.error && (!prevProps.courseInfo || !prevProps.courseInfo.error)) {
+      window.scrollTo(0, 0);
+    }
+  }
+
   setStartedFetching() {
     this.setState({ startedFetching: true });
   }
@@ -164,6 +171,14 @@ class CreateCoursePage extends React.Component {
           { showForm
           && (
             <div>
+              {errorArray.length > 1 && (
+                <Alert
+                  id="create-error"
+                  variant="danger"
+                >
+                  {errorArray}
+                </Alert>
+              ) }
               <CreateCourseForm
                 id="create-course-form"
                 onSubmit={this.showModal}
@@ -173,15 +188,8 @@ class CreateCoursePage extends React.Component {
                 isCreating={courseInfo.isCreating}
                 courseOptions={courseOptions}
                 courseRunOptions={courseRunOptions}
+                onChange={this.props.clearCourseInfoErrors}
               />
-              {errorArray.length > 1 && (
-                <Alert
-                  id="create-error"
-                  variant="danger"
-                >
-                  {errorArray}
-                </Alert>
-              ) }
             </div>
           )}
         </PageContainer>

--- a/src/components/DateTimeField/index.jsx
+++ b/src/components/DateTimeField/index.jsx
@@ -35,7 +35,7 @@ class DateTimeField extends React.Component {
   }
 
   concatDateTime(date, time) {
-    let datetime = moment(`${date} ${time}`, 'YYYY/MM/DD HH:mm');
+    let datetime = moment(`${date} ${time}`, ['YYYY/MM/DD HH:mm', 'YYYY-MM-DD HH:mm'], true);
     datetime = this.props.utcTimeZone
       ? datetime.format(DATE_FORMAT)
       : datetime.utc().format(DATE_FORMAT);
@@ -74,6 +74,10 @@ class DateTimeField extends React.Component {
       type,
       pattern,
       placeholder,
+      meta: {
+        touched,
+        error,
+      },
     } = this.props;
 
     const {
@@ -82,9 +86,9 @@ class DateTimeField extends React.Component {
     } = this.state;
 
     return (
-      <div className="row">
+      <div className="row" name={name}>
         <div className="col-6">
-          <Form.Group controlId={`${name}-date-label`}>
+          <Form.Group controlId={`${name}-date-label`} isInvalid={touched && error}>
             <Form.Label>
               <FieldLabel
                 id={`${name}-date-label`}
@@ -107,10 +111,15 @@ class DateTimeField extends React.Component {
               min={minDate}
               onInvalid={onInvalid}
             />
+            {touched && error && (
+            <Form.Control.Feedback hasIcon={this.props.errHasIcon}>
+              {error}
+            </Form.Control.Feedback>
+            )}
           </Form.Group>
         </div>
         <div className="col-6">
-          <Form.Group controlId={`${name}-date-label`}>
+          <Form.Group controlId={`${name}-time-label`}>
             <Form.Label>
               <FieldLabel
                 id={`${name}-time-label`}
@@ -125,7 +134,7 @@ class DateTimeField extends React.Component {
               placeholder="HH:mm"
               required={required}
               disabled={disabled}
-              onChange={event => this.updateDate(event.target.value)}
+              onChange={event => this.updateTime(event.target.value)}
             />
           </Form.Group>
         </div>
@@ -152,6 +161,11 @@ DateTimeField.propTypes = {
   type: PropTypes.string,
   pattern: PropTypes.string,
   placeholder: PropTypes.string,
+  meta: PropTypes.shape({
+    touched: PropTypes.bool,
+    error: PropTypes.string,
+  }).isRequired,
+  errHasIcon: PropTypes.bool,
 };
 
 DateTimeField.defaultProps = {
@@ -164,6 +178,7 @@ DateTimeField.defaultProps = {
   type: '',
   pattern: 'dd/mm/yyyy',
   placeholder: '',
+  errHasIcon: false,
 };
 
 export default DateTimeField;

--- a/src/components/PriceList/__snapshots__/PriceList.test.jsx.snap
+++ b/src/components/PriceList/__snapshots__/PriceList.test.jsx.snap
@@ -25,8 +25,18 @@ exports[`PriceList renders with price labels 1`] = `
       />
     }
     name="prices.a"
+    props={
+      Object {
+        "name": "prices.a",
+      }
+    }
     required={false}
-    type="number"
+    validate={
+      Array [
+        [Function],
+        [Function],
+      ]
+    }
   />
   <Field
     component={[Function]}
@@ -51,8 +61,18 @@ exports[`PriceList renders with price labels 1`] = `
       />
     }
     name="prices.b"
+    props={
+      Object {
+        "name": "prices.b",
+      }
+    }
     required={false}
-    type="number"
+    validate={
+      Array [
+        [Function],
+        [Function],
+      ]
+    }
   />
 </Fragment>
 `;

--- a/src/components/PriceList/index.jsx
+++ b/src/components/PriceList/index.jsx
@@ -5,6 +5,11 @@ import { Field } from 'redux-form';
 import RenderInputTextField from '../RenderInputTextField';
 import FieldLabel from '../FieldLabel';
 
+import { isSafari } from '../../utils';
+import {
+  requiredValidate, priceValidate, noValidate,
+} from '../../utils/validation';
+
 const PriceList = ({
   disabled,
   extraInput,
@@ -17,13 +22,14 @@ const PriceList = ({
         key={seatType}
         name={`prices.${seatType}`}
         component={RenderInputTextField}
+        props={{ name: `prices.${seatType}` }}
         extraInput={{
           min: 1.00,
           step: 0.01,
           max: 10000.00,
           ...extraInput,
         }}
-        type="number"
+        {...(isSafari ? {} : { type: 'number' })}
         label={(
           <FieldLabel
             text={`${priceLabels[seatType]} Price (USD)`}
@@ -32,6 +38,7 @@ const PriceList = ({
 )}
         disabled={disabled}
         required={required}
+        validate={[required ? requiredValidate : noValidate, priceValidate]}
       />
     ))}
   </>

--- a/src/components/RenderInputTextField/index.jsx
+++ b/src/components/RenderInputTextField/index.jsx
@@ -14,6 +14,7 @@ const RenderInputTextField = ({
   placeholder,
   pattern,
   meta: { touched, error },
+  errHasIcon,
 }) => (
   <Form.Group controlId={`${name}-text-label`} isInvalid={touched && error}>
     <Form.Label>
@@ -32,7 +33,7 @@ const RenderInputTextField = ({
       required={required}
     />
     {touched && error && (
-    <Form.Control.Feedback>
+    <Form.Control.Feedback hasIcon={errHasIcon}>
       {error}
     </Form.Control.Feedback>
     )}
@@ -47,6 +48,7 @@ RenderInputTextField.defaultProps = {
   maxLength: '',
   placeholder: '',
   pattern: null,
+  errHasIcon: false,
 };
 
 RenderInputTextField.propTypes = {
@@ -64,6 +66,7 @@ RenderInputTextField.propTypes = {
   maxLength: PropTypes.string,
   placeholder: PropTypes.string,
   pattern: PropTypes.string,
+  errHasIcon: PropTypes.bool,
 };
 
 export default RenderInputTextField;

--- a/src/components/RenderSelectField/index.jsx
+++ b/src/components/RenderSelectField/index.jsx
@@ -11,6 +11,7 @@ const RenderSelectField = ({
   required,
   meta: { touched, error },
   options,
+  errHasIcon,
 }) => (
   <Form.Group controlId={`${name}-text-label`} isInvalid={touched && error}>
     <Form.Label>
@@ -29,7 +30,7 @@ const RenderSelectField = ({
         <option key={option.value} value={option.value}>{option.label}</option>
       ))}
       {touched && error && (
-      <Form.Control.Feedback>
+      <Form.Control.Feedback hasIcon={errHasIcon}>
         {error}
       </Form.Control.Feedback>
       )}
@@ -42,6 +43,7 @@ RenderSelectField.defaultProps = {
   name: '',
   disabled: false,
   required: false,
+  errHasIcon: false,
 };
 
 RenderSelectField.propTypes = {
@@ -59,6 +61,7 @@ RenderSelectField.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.object),
   ]).isRequired,
+  errHasIcon: PropTypes.bool,
 };
 
 export default RenderSelectField;

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -17,3 +17,7 @@
 ::-webkit-search-cancel-button {
   display: none;
 }
+
+.create-course-form * {
+  scroll-margin-top: 60px;
+}

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -50,7 +50,7 @@ describe('getFieldName', () => {
       ],
       full_description: 'This field is required',
     };
-    expect(getFieldName(errors)).toEqual('course_runs[1].transcript_languages');
+    expect(getFieldName(errors)).toEqual('course_runs[1].transcript_languages._error');
   });
 
   it('returns the first full field name in errors for deeply nested fields', () => {


### PR DESCRIPTION
# [PROD-2734](https://2u-internal.atlassian.net/browse/PROD-2734)

## Description

This PR updates the Publisher create course form to incorporate edx/paragon based validation for form fields

## Testing Instructions

1. On the publisher landing page, click on `New Course`. 
2. Fill in the details for this new course whilst intentionally missing some required fields.
3. Submit the form and observe the error messages.

## ScreenShots
### Before
<img width="1680" alt="Screenshot 2022-12-16 at 12 52 10 AM" src="https://user-images.githubusercontent.com/87228907/208006798-8d94f568-fb08-4ebd-96ae-58c6aebaf923.png">

### After
<img width="1669" alt="Screenshot 2022-12-16 at 12 50 45 AM" src="https://user-images.githubusercontent.com/87228907/208006848-9f1457eb-009e-42c9-817f-414c5dd171c0.png">


## ToDo

- Update test snapshots
