### PR TITLE
fix: ensure prepush lint returns error on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy:gh-pages": "npm run build && gh-pages -d dist",
     "lint": "fedx-scripts eslint --ext .jsx,.js .",
     "lint-fix": "fedx-scripts eslint --ext .jsx,.js . --fix",
-    "prepush": "npm run lint; npm run stylelint",
+    "prepush": "npm run lint && npm run stylelint",
     "prepublishOnly": "npm run build",
     "start": "fedx-scripts webpack-dev-server --progress",
     "debug-test": "node --inspect-brk node_modules/.bin/jest --coverage --runInBand",


### PR DESCRIPTION
After making https://github.com/openedx/frontend-app-admin-portal/pull/1014, I did a full search of the org for `; npm run` and ended up here. I updated `prepush` in `package.json` to use `&&` instead of `;` to ensure we return an error code on lint failure.