### PR TITLE
fix: css override for modal header

### DIFF
--- a/src/components/BulkOperationDetailsPage/BulkOperationDetails.jsx
+++ b/src/components/BulkOperationDetailsPage/BulkOperationDetails.jsx
@@ -128,6 +128,7 @@ const BulkOperationDetails = ({ task }) => {
           Preview CSV
         </Button>
         <FullscreenModal
+          className="csv-preview-fs-modal"
           title="CSV Preview"
           isOpen={isOpen}
           onClose={close}

--- a/src/components/BulkOperationDetailsPage/styles.scss
+++ b/src/components/BulkOperationDetailsPage/styles.scss
@@ -3,6 +3,7 @@
 $cell-widths: 220px;
 
 .csv-preview-modal {
+
     .pgn__data-table-layout-wrapper {
         display: block;
     }
@@ -23,11 +24,12 @@ $cell-widths: 220px;
     }
 }
 
-.pgn__modal-header {
+.csv-preview-fs-modal {
+  .pgn__modal-header {
     background-color: #0A3055 !important;
-    color: white;
+    color: white !important;
+  }
 }
-
 
 .bulk-op-details-table-container {
   thead {


### PR DESCRIPTION
This PR fixes css override for modal header

![image](https://github.com/user-attachments/assets/44445870-a41d-4e17-be2c-d43c6f021a83)
