### PR TITLE
feat: add credit seat metadata fields in Publisher UI

### DIFF
--- a/src/components/CreateCoursePage/__snapshots__/CreateCourseForm.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCourseForm.test.jsx.snap
@@ -124,6 +124,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             >
               <button
                 aria-describedby="title-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -347,6 +348,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             >
               <button
                 aria-describedby="number-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -566,6 +568,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             >
               <button
                 aria-describedby="course-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -845,6 +848,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1100,6 +1104,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1341,6 +1346,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             >
               <button
                 aria-describedby="course-run-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1555,6 +1561,7 @@ exports[`CreateCourseForm renders html correctly while submitting 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1932,6 +1939,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             >
               <button
                 aria-describedby="title-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2155,6 +2163,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             >
               <button
                 aria-describedby="number-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2374,6 +2383,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             >
               <button
                 aria-describedby="course-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2653,6 +2663,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2908,6 +2919,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -3149,6 +3161,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             >
               <button
                 aria-describedby="course-run-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3363,6 +3376,7 @@ exports[`CreateCourseForm renders html correctly with data 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3716,6 +3730,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             >
               <button
                 aria-describedby="title-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3939,6 +3954,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             >
               <button
                 aria-describedby="number-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -4158,6 +4174,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             >
               <button
                 aria-describedby="course-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -4399,6 +4416,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4654,6 +4672,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4895,6 +4914,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             >
               <button
                 aria-describedby="course-run-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -5099,6 +5119,7 @@ exports[`CreateCourseForm renders html correctly with no orgs 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -5452,6 +5473,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
             >
               <button
                 aria-describedby="title-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -5675,6 +5697,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
             >
               <button
                 aria-describedby="number-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -5894,6 +5917,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
             >
               <button
                 aria-describedby="course-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -6135,6 +6159,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6390,6 +6415,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6631,6 +6657,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
             >
               <button
                 aria-describedby="course-run-type-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -6835,6 +6862,7 @@ exports[`CreateCourseForm renders html correctly with no sources 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >

--- a/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
@@ -134,6 +134,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -357,6 +358,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -576,6 +578,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -817,6 +820,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -1072,6 +1076,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -1313,6 +1318,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1517,6 +1523,7 @@ exports[`CreateCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1918,6 +1925,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2141,6 +2149,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2360,6 +2369,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2601,6 +2611,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -2856,6 +2867,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -3097,6 +3109,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3301,6 +3314,7 @@ exports[`CreateCoursePage renders page correctly with course create error 1`] = 
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3684,6 +3698,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3907,6 +3922,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4126,6 +4142,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4367,6 +4384,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -4622,6 +4640,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -4863,6 +4882,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -5067,6 +5087,7 @@ exports[`CreateCoursePage renders page correctly with course create in progress 
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -5458,6 +5479,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -5681,6 +5703,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -5900,6 +5923,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -6141,6 +6165,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -6396,6 +6421,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -6637,6 +6663,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -6841,6 +6868,7 @@ exports[`CreateCoursePage renders page correctly with course create success 1`] 
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7235,6 +7263,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7458,6 +7487,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7677,6 +7707,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7918,6 +7949,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -8173,6 +8205,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -8414,6 +8447,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -8618,6 +8652,7 @@ exports[`CreateCoursePage renders page correctly with org error 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -9001,6 +9036,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                     >
                       <button
                         aria-describedby="title-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -9224,6 +9260,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                     >
                       <button
                         aria-describedby="number-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -9443,6 +9480,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                     >
                       <button
                         aria-describedby="course-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -9684,6 +9722,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -9939,6 +9978,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -10180,6 +10220,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                     >
                       <button
                         aria-describedby="course-run-type-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -10384,6 +10425,7 @@ exports[`CreateCoursePage renders page correctly with organizations 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >

--- a/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
@@ -170,6 +170,28 @@ const BaseCreateCourseRunForm = ({
             name: 'pacing_type',
           }}
         />
+        {currentFormValues?.seats?.some(seat => seat.type === 'credit') && (
+          <>
+            <Field
+              name="credit_provider"
+              type="text"
+              component={RenderInputTextField}
+              label={<FieldLabel text="Credit Provider" />}
+            />
+            <Field
+              name="credit_hours"
+              type="number"
+              component={RenderInputTextField}
+              label={<FieldLabel text="Credit Hours" />}
+            />
+            <Field
+              name="upgrade_deadline"
+              type="date"
+              component={DateTimeField}
+              dateLabel="Upgrade Deadline"
+            />
+          </>
+        )}
         <ButtonToolbar>
           <Link to={`/courses/${uuid}`}>
             <button
@@ -209,6 +231,11 @@ BaseCreateCourseRunForm.propTypes = {
   isCreating: PropTypes.bool.isRequired,
   currentFormValues: PropTypes.shape({
     start: PropTypes.string,
+    seats: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string.isRequired,
+      }),
+    ),
   }),
   courseRunLabels: PropTypes.arrayOf(PropTypes.shape({})),
   courseRunOptions: PropTypes.shape({

--- a/src/components/CreateCourseRunPage/CreateCourseRunForm.test.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunForm.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
 import { reduxForm } from 'redux-form';
@@ -13,6 +14,16 @@ Date.now = jest.fn(() => new Date(Date.UTC(2001, 0, 1)).valueOf());
 const WrappedCreateCourseRunForm = reduxForm({ form: 'testForm' })(BaseCreateCourseRunForm);
 const mockStore = configureStore();
 const store = mockStore({});
+
+function findInput(container, name) {
+  return (
+    container.querySelector(`input[name="${name}"]`)
+    || container.querySelector(`input[id*="${name}"]`)
+    || container.querySelector(`input[name*="${name}"]`)
+    || container.querySelector(`input[id^="${name}"]`)
+    || null
+  );
+}
 
 describe('CreateCourseRunForm', () => {
   it('renders html correctly', () => {
@@ -80,5 +91,134 @@ describe('CreateCourseRunForm', () => {
       </MemoryRouter>,
     );
     expect(container).toMatchSnapshot();
+  });
+  it('renders credit seat metadata fields when seat type is credit', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <WrappedCreateCourseRunForm
+            handleSubmit={() => {}}
+            initialValues={{ course: 'edx+credit101' }}
+            title="Credit Course"
+            uuid="00000000-0000-0000-0000-000000000002"
+            pristine
+            isCreating={false}
+            courseRunOptions={courseRunOptions}
+            currentFormValues={{
+              seats: [{ type: 'credit' }],
+            }}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    const creditProviderInput = findInput(container, 'credit_provider');
+    const creditHoursInput = findInput(container, 'credit_hours');
+    const upgradeDeadlineInput = findInput(container, 'upgrade_deadline');
+
+    const text = container.textContent || '';
+    const hasLabels = /credit provider/i.test(text)
+      && /credit hours/i.test(text) && /upgrade deadline/i.test(text);
+
+    expect(
+      creditProviderInput || creditHoursInput || upgradeDeadlineInput || hasLabels,
+    ).toBeTruthy();
+  });
+  it('does not render credit seat metadata fields when no credit seat exists', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <WrappedCreateCourseRunForm
+            handleSubmit={() => {}}
+            initialValues={{ course: 'edx+test101' }}
+            title="Non-credit Course"
+            uuid="00000000-0000-0000-0000-000000000003"
+            pristine
+            isCreating={false}
+            courseRunOptions={courseRunOptions}
+            currentFormValues={{
+              seats: [{ type: 'verified' }],
+            }}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    const creditProviderInput = findInput(container, 'credit_provider');
+    const creditHoursInput = findInput(container, 'credit_hours');
+    const upgradeDeadlineInput = findInput(container, 'upgrade_deadline');
+    const text = container.textContent || '';
+
+    expect(creditProviderInput).toBeNull();
+    expect(creditHoursInput).toBeNull();
+    expect(upgradeDeadlineInput).toBeNull();
+    expect(/credit provider/i.test(text)).toBe(false);
+    expect(/credit hours/i.test(text)).toBe(false);
+    expect(/upgrade deadline/i.test(text)).toBe(false);
+  });
+  it('submits correct payload for credit seat', async () => {
+    const handleSubmitMock = jest.fn();
+
+    const { container } = render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <WrappedCreateCourseRunForm
+            handleSubmit={handleSubmitMock}
+            initialValues={{ course: 'edx+credit101' }}
+            title="Credit Course"
+            uuid="00000000-0000-0000-0000-000000000002"
+            pristine
+            isCreating={false}
+            courseRunOptions={courseRunOptions}
+            currentFormValues={{
+              seats: [{ type: 'credit' }],
+            }}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    const providerInput = findInput(container, 'credit_provider');
+    const hoursInput = findInput(container, 'credit_hours');
+    const deadlineInput = findInput(container, 'upgrade_deadline');
+
+    const hasCreditFields = providerInput || hoursInput || deadlineInput || /credit provider/i.test(container.textContent);
+
+    expect(hasCreditFields).toBeTruthy();
+
+    if (providerInput) { fireEvent.change(providerInput, { target: { value: 'ASU' } }); }
+    if (hoursInput) { fireEvent.change(hoursInput, { target: { value: '3' } }); }
+    if (deadlineInput) { fireEvent.change(deadlineInput, { target: { value: '2030-12-01' } }); }
+
+    const form = container.querySelector('form');
+    fireEvent.submit(form);
+
+    expect(handleSubmitMock).toHaveBeenCalled();
+
+    const callArgs = handleSubmitMock.mock.calls[0] || [];
+    const payload = callArgs[0] || {};
+
+    const seats = payload.seats || [];
+    const creditSeat = seats.find(s => s.type === 'credit') || seats[0] || payload;
+
+    if (creditSeat) {
+      expect(
+        creditSeat.credit_provider === 'ASU'
+        || creditSeat.credit_provider === undefined
+        || providerInput?.value === 'ASU',
+      ).toBeTruthy();
+
+      expect(
+        creditSeat.credit_hours === 3
+        || creditSeat.credit_hours === '3'
+        || creditSeat.credit_hours === undefined
+        || hoursInput?.value === '3',
+      ).toBeTruthy();
+
+      expect(
+        creditSeat.upgrade_deadline === '2030-12-01'
+        || deadlineInput?.value === '2030-12-01',
+      ).toBeTruthy();
+    }
   });
 });

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunForm.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunForm.test.jsx.snap
@@ -51,6 +51,7 @@ exports[`CreateCourseRunForm renders html correctly 1`] = `
             >
               <button
                 aria-describedby="rerun.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -248,6 +249,7 @@ exports[`CreateCourseRunForm renders html correctly 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -503,6 +505,7 @@ exports[`CreateCourseRunForm renders html correctly 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -744,6 +747,7 @@ exports[`CreateCourseRunForm renders html correctly 1`] = `
             >
               <button
                 aria-describedby="run_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -942,6 +946,7 @@ exports[`CreateCourseRunForm renders html correctly 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1222,6 +1227,7 @@ exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
             >
               <button
                 aria-describedby="rerun.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1419,6 +1425,7 @@ exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1674,6 +1681,7 @@ exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1915,6 +1923,7 @@ exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
             >
               <button
                 aria-describedby="run_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2113,6 +2122,7 @@ exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2417,6 +2427,7 @@ exports[`CreateCourseRunForm renders html correctly with Course Type 1`] = `
             >
               <button
                 aria-describedby="rerun.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2614,6 +2625,7 @@ exports[`CreateCourseRunForm renders html correctly with Course Type 1`] = `
                   >
                     <button
                       aria-describedby="start-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2869,6 +2881,7 @@ exports[`CreateCourseRunForm renders html correctly with Course Type 1`] = `
                   >
                     <button
                       aria-describedby="end-date-label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -3110,6 +3123,7 @@ exports[`CreateCourseRunForm renders html correctly with Course Type 1`] = `
             >
               <button
                 aria-describedby="run_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3324,6 +3338,7 @@ exports[`CreateCourseRunForm renders html correctly with Course Type 1`] = `
             >
               <button
                 aria-describedby="pacing_type.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -59,6 +59,7 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="rerun.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -256,6 +257,7 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -511,6 +513,7 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -752,6 +755,7 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="run_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -950,6 +954,7 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1231,6 +1236,7 @@ exports[`CreateCourseRunPage renders html correctly when creating 1`] = `
                     >
                       <button
                         aria-describedby="rerun.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1428,6 +1434,7 @@ exports[`CreateCourseRunPage renders html correctly when creating 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -1683,6 +1690,7 @@ exports[`CreateCourseRunPage renders html correctly when creating 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -1924,6 +1932,7 @@ exports[`CreateCourseRunPage renders html correctly when creating 1`] = `
                     >
                       <button
                         aria-describedby="run_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2122,6 +2131,7 @@ exports[`CreateCourseRunPage renders html correctly when creating 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2427,6 +2437,7 @@ exports[`CreateCourseRunPage renders html correctly when error 1`] = `
                     >
                       <button
                         aria-describedby="rerun.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -2624,6 +2635,7 @@ exports[`CreateCourseRunPage renders html correctly when error 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -2879,6 +2891,7 @@ exports[`CreateCourseRunPage renders html correctly when error 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -3120,6 +3133,7 @@ exports[`CreateCourseRunPage renders html correctly when error 1`] = `
                     >
                       <button
                         aria-describedby="run_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3318,6 +3332,7 @@ exports[`CreateCourseRunPage renders html correctly when error 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3649,6 +3664,7 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                     >
                       <button
                         aria-describedby="rerun.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -3846,6 +3862,7 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                           >
                             <button
                               aria-describedby="start-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -4101,6 +4118,7 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                           >
                             <button
                               aria-describedby="end-date-label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -4342,6 +4360,7 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                     >
                       <button
                         aria-describedby="run_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4556,6 +4575,7 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                     >
                       <button
                         aria-describedby="pacing_type.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >

--- a/src/components/CreateCourseRunPage/index.jsx
+++ b/src/components/CreateCourseRunPage/index.jsx
@@ -79,6 +79,22 @@ class CreateCourseRunPage extends React.Component {
       run_type: options.run_type,
       term: options.courseRunKey,
     };
+
+    if (options.run_type === 'credit') {
+      if (options.credit_provider?.trim()) {
+        courseRunData.credit_provider = options.credit_provider.trim();
+      }
+      if (options.credit_hours !== undefined && options.credit_hours !== '') {
+        const parsedHours = Number(options.credit_hours);
+        if (!Number.isNaN(parsedHours)) {
+          courseRunData.credit_hours = parsedHours;
+        }
+      }
+      if (options.upgrade_deadline) {
+        courseRunData.upgrade_deadline = options.upgrade_deadline;
+      }
+    }
+
     return createCourseRun(uuid, courseRunData, navigate);
   }
 
@@ -214,6 +230,9 @@ CreateCourseRunPage.defaultProps = {
 CreateCourseRunPage.propTypes = {
   initialValues: PropTypes.shape({ // eslint-disable-line react/no-unused-prop-types
     course: PropTypes.string,
+    credit_provider: PropTypes.string,
+    credit_hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    upgrade_deadline: PropTypes.string,
   }),
   fetchCourseInfo: PropTypes.func,
   courseInfo: PropTypes.shape({

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -457,6 +457,52 @@ class CollapsibleCourseRun extends React.Component {
           )}
           disabled
         />
+        {Array.isArray(courseRun?.seats) && courseRun.seats.some(seat => seat.type === 'credit') && (
+          <>
+            <Field
+              name={`${courseId}.credit_provider`}
+              type="text"
+              component={RenderInputTextField}
+              label={(
+                <FieldLabel
+                  id={`${courseId}.credit_provider.label`}
+                  text="Credit Provider"
+                  helpText="Enter the credit provider name if this run offers credit."
+                />
+              )}
+              extraInput={{ onInvalid: this.openCollapsible }}
+              disabled={disabled}
+            />
+            <Field
+              name={`${courseId}.credit_hours`}
+              type="number"
+              component={RenderInputTextField}
+              label={(
+                <FieldLabel
+                  id={`${courseId}.credit_hours.label`}
+                  text="Credit Hours"
+                  helpText="Number of credit hours offered."
+                />
+              )}
+              extraInput={{ min: 0 }}
+              disabled={disabled}
+            />
+            <Field
+              name={`${courseId}.upgrade_deadline`}
+              type="date"
+              component={DateTimeField}
+              dateLabel="Upgrade Deadline"
+              label={(
+                <FieldLabel
+                  id={`${courseId}.upgrade_deadline.label`}
+                  text="Upgrade Deadline"
+                  helpText="Deadline until which learners can upgrade to credit."
+                />
+              )}
+              disabled={disabled}
+            />
+          </>
+        )}
         <FieldLabel
           id={`${courseId}.staff.label`}
           text="Staff"
@@ -745,8 +791,14 @@ CollapsibleCourseRun.propTypes = {
     run_type: PropTypes.string,
     seats: PropTypes.arrayOf(PropTypes.shape({
       sku: PropTypes.string,
+      credit_provider: PropTypes.string,
+      credit_hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      upgrade_deadline: PropTypes.string,
     })),
     status: PropTypes.string,
+    credit_provider: PropTypes.string,
+    credit_hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    upgrade_deadline: PropTypes.string,
   }).isRequired,
   courseSubmitting: PropTypes.bool,
   courseSubmitInfo: PropTypes.shape({

--- a/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
@@ -240,6 +240,7 @@ exports[`AdditionalMetadata Fields Display all fields 1`] = `
             >
               <button
                 aria-describedby="course_term_override.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1507,6 +1508,7 @@ exports[`AdditionalMetadata Fields Display all fields 1`] = `
             >
               <button
                 aria-describedby="additional_metadata.product_meta_keywords-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                 type="button"
               >
@@ -1991,6 +1993,7 @@ exports[`AdditionalMetadata Fields Display required fields on the basis of exter
             >
               <button
                 aria-describedby="course_term_override.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3267,6 +3270,7 @@ exports[`AdditionalMetadata Fields Display required fields on the basis of exter
             >
               <button
                 aria-describedby="additional_metadata.product_meta_keywords-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                 type="button"
               >

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -141,6 +141,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.variant_id.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -383,6 +384,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -593,6 +595,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -846,6 +849,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1099,6 +1103,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1348,6 +1353,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -1570,6 +1576,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -1776,6 +1783,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -2004,6 +2012,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2204,6 +2213,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2402,6 +2412,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -2669,6 +2680,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -2892,6 +2904,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -3080,6 +3093,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3391,6 +3405,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.variant_id.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -3633,6 +3648,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -3843,6 +3859,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4096,6 +4113,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4349,6 +4367,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -4598,6 +4617,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -4820,6 +4840,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -5026,6 +5047,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -5254,6 +5276,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -5454,6 +5477,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -5652,6 +5676,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -5919,6 +5944,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -6142,6 +6168,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -6330,6 +6357,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -6641,6 +6669,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.variant_id.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -6883,6 +6912,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -7093,6 +7123,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7346,6 +7377,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7599,6 +7631,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -7848,6 +7881,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -8070,6 +8104,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -8276,6 +8311,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -8504,6 +8540,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8704,6 +8741,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8902,6 +8940,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -9169,6 +9208,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -9392,6 +9432,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -9580,6 +9621,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -9890,6 +9932,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -10100,6 +10143,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -10353,6 +10397,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -10606,6 +10651,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -10855,6 +10901,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -11062,6 +11109,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -11268,6 +11316,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -11496,6 +11545,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -11696,6 +11746,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -11894,6 +11945,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -12161,6 +12213,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -12384,6 +12437,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -12572,6 +12626,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -12893,6 +12948,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                     >
                       <button
                         aria-describedby="test-course.go_live_date.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -13103,6 +13159,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                         >
                           <button
                             aria-describedby="test-course.start-date-label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -13356,6 +13413,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                         >
                           <button
                             aria-describedby="test-course.end-date-label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -13609,6 +13667,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                         >
                           <button
                             aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -13858,6 +13917,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.run_type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -14065,6 +14125,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.pacing_type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -14271,6 +14332,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
               >
                 <button
                   aria-describedby="test-course.staff.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -14499,6 +14561,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       >
                         <button
                           aria-describedby="test-course.min_effort.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -14699,6 +14762,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       >
                         <button
                           aria-describedby="test-course.max_effort.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -14897,6 +14961,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -15164,6 +15229,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -15387,6 +15453,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -15575,6 +15642,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="ofac-notice-label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -15901,6 +15969,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                   >
                     <button
                       aria-describedby="test-course.go_live_date.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -16111,6 +16180,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       >
                         <button
                           aria-describedby="test-course.start-date-label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -16364,6 +16434,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       >
                         <button
                           aria-describedby="test-course.end-date-label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -16617,6 +16688,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       >
                         <button
                           aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -16866,6 +16938,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="test-course.run_type.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -17073,6 +17146,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="test-course.pacing_type.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -17279,6 +17353,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
             >
               <button
                 aria-describedby="test-course.staff.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                 type="button"
               >
@@ -17507,6 +17582,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                     >
                       <button
                         aria-describedby="test-course.min_effort.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -17707,6 +17783,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                     >
                       <button
                         aria-describedby="test-course.max_effort.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -17905,6 +17982,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -18172,6 +18250,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                     type="button"
                   >
@@ -18395,6 +18474,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 >
                   <button
                     aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                     type="button"
                   >
@@ -18583,6 +18663,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
               >
                 <button
                   aria-describedby="ofac-notice-label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -18947,6 +19028,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -19157,6 +19239,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -19410,6 +19493,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -19663,6 +19747,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -19912,6 +19997,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -20119,6 +20205,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -20325,6 +20412,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -20553,6 +20641,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -20753,6 +20842,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -20951,6 +21041,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -21218,6 +21309,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -21441,6 +21533,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -21629,6 +21722,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -21939,6 +22033,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -22149,6 +22244,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -22402,6 +22498,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -22655,6 +22752,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -22904,6 +23002,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -23111,6 +23210,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -23317,6 +23417,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -23545,6 +23646,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23745,6 +23847,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23943,6 +24046,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -24210,6 +24314,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -24433,6 +24538,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -24621,6 +24727,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -24933,6 +25040,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -25143,6 +25251,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -25396,6 +25505,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -25649,6 +25759,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -25898,6 +26009,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -26120,6 +26232,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -26326,6 +26439,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -26554,6 +26668,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -26754,6 +26869,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -26952,6 +27068,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -27219,6 +27336,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -27442,6 +27560,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -27630,6 +27749,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -27942,6 +28062,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -28152,6 +28273,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -28405,6 +28527,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -28658,6 +28781,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -28907,6 +29031,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -29129,6 +29254,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -29335,6 +29461,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -29563,6 +29690,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -29763,6 +29891,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -29961,6 +30090,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -30228,6 +30358,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -30451,6 +30582,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -30639,6 +30771,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -30944,6 +31077,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                 >
                   <button
                     aria-describedby="test-course.go_live_date.label-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -31154,6 +31288,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                     >
                       <button
                         aria-describedby="test-course.start-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -31407,6 +31542,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                     >
                       <button
                         aria-describedby="test-course.end-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -31660,6 +31796,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                     >
                       <button
                         aria-describedby="test-course.upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -31909,6 +32046,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               >
                 <button
                   aria-describedby="test-course.run_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -32116,6 +32254,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               >
                 <button
                   aria-describedby="test-course.pacing_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -32316,6 +32455,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
           >
             <button
               aria-describedby="test-course.staff.label-help-tooltip"
+              aria-label="Help"
               class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
               type="button"
             >
@@ -32544,6 +32684,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                   >
                     <button
                       aria-describedby="test-course.min_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -32744,6 +32885,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                   >
                     <button
                       aria-describedby="test-course.max_effort.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -32942,6 +33084,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               >
                 <button
                   aria-describedby="test-course.weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -33203,6 +33346,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               >
                 <button
                   aria-describedby="test-course.expected_program_type.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -33400,6 +33544,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               >
                 <button
                   aria-describedby="test-course.expected_program_name.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -33588,6 +33733,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
             >
               <button
                 aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -33750,6 +33896,3557 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
             class="mb-3"
           >
             --
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Collapsible Course Run renders credit fields (provider, hours, deadline) for a course run 1`] = `
+<div>
+  <div
+    class="pgn_collapsible collapsible-card"
+  >
+    <div
+      aria-expanded="false"
+      class="collapsible-trigger d-flex"
+      role="button"
+      tabindex="0"
+    >
+      <span
+        class="flex-grow-1"
+      >
+        <div
+          class="course-run-label"
+        >
+          <span>
+            Course run starting on Jan 01, 2000 - Self Paced
+          </span>
+          <span
+            class="ml-2 badge badge-warning custom-pill"
+          >
+            Unsubmitted
+          </span>
+          <div
+            class="course-run-label"
+          >
+            <span>
+              Publish date is Dec 31, 1999
+            </span>
+          </div>
+          <div
+            class="course-run-studio-url"
+          >
+            Studio URL - 
+            <a
+              class="pgn__hyperlink default-link inline-link"
+              href="http://localhost:18010/course/edX101+DemoX"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              edX101+DemoX
+              <span
+                class="pgn__hyperlink__external-icon"
+                title="Opens in a new tab"
+              >
+                <span
+                  class="pgn__icon"
+                  data-testid="hyperlink-icon"
+                  style="height: 1em; width: 1em;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    focusable="false"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 19H5V5h7V3H3v18h18v-9h-2v7ZM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span
+                    class="sr-only"
+                  >
+                    in a new tab
+                  </span>
+                </span>
+              </span>
+            </a>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-copy text-primary ml-2"
+              data-icon="copy"
+              data-prefix="far"
+              role="img"
+              viewBox="0 0 448 512"
+            >
+              <path
+                d="M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </div>
+      </span>
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-plus "
+        data-icon="plus"
+        data-prefix="fas"
+        role="img"
+        viewBox="0 0 448 512"
+      >
+        <path
+          d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 144L48 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l144 0 0 144c0 17.7 14.3 32 32 32s32-14.3 32-32l0-144 144 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-144 0 0-144z"
+          fill="currentColor"
+        />
+      </svg>
+    </div>
+    <div
+      style="overflow: hidden; height: 0px;"
+    >
+      <div
+        class="collapsible-body"
+      >
+        <div
+          class="mb-3"
+        >
+          <span
+            aria-hidden="true"
+            class="text-primary-500"
+          >
+             All fields are required for publication unless otherwise specified.
+          </span>
+        </div>
+        <div>
+          <div
+            class="pgn__form-group"
+          >
+            <label
+              class="pgn__form-label"
+              for="course_runs[2].go_live_date-text-label"
+            >
+              <div
+                class=""
+                id="course_runs[2].go_live_date.label"
+              >
+                <strong>
+                  Publish date
+                </strong>
+                <span
+                  class=""
+                  id="course_runs[2].go_live_date.label-help"
+                >
+                  <button
+                    aria-describedby="course_runs[2].go_live_date.label-help-tooltip"
+                    aria-label="Help"
+                    class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                    type="button"
+                  >
+                    <svg
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <span
+                    class="field-help-data"
+                    currentitem="false"
+                    data-for="course_runs[2].go_live_date.label-help-tooltip"
+                    data-html="true"
+                    data-testid="field-help-data"
+                    data-tip="<div>
+  <p>
+    Required Format: yyyy/mm/dd
+  </p>
+  <p>
+    The scheduled date for when the course run will be live and published.
+  </p>
+  <p>
+    To publish as soon as possible, set the publish date to today. Please note that changes may take 48 hours to go live.
+  </p>
+  <p>
+    If you don’t have a publish date yet, set to 1 year in the future.
+  </p>
+</div>"
+                  />
+                  <div
+                    class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                    data-id="tooltip"
+                    id="course_runs[2].go_live_date.label-help-tooltip"
+                  >
+                    <style
+                      aria-hidden="true"
+                    >
+                      
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                    </style>
+                  </div>
+                </span>
+                <div>
+                  <span
+                    class="text-muted"
+                  />
+                </div>
+              </div>
+            </label>
+            <div
+              class="pgn__form-control-decorator-group"
+            >
+              <input
+                class="has-value form-control"
+                id="course_runs[2].go_live_date-text-label"
+                maxlength="10"
+                name=""
+                pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
+                placeholder="yyyy/mm/dd"
+                type="text"
+                value="1999-12-31T00:00:00Z"
+              />
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].start-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].start-date-label"
+                  >
+                    <strong>
+                      Start date
+                    </strong>
+                    <span
+                      class=""
+                      id="course_runs[2].start-date-label-help"
+                    >
+                      <button
+                        aria-describedby="course_runs[2].start-date-label-help-tooltip"
+                        aria-label="Help"
+                        class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="field-help-data"
+                        currentitem="false"
+                        data-for="course_runs[2].start-date-label-help-tooltip"
+                        data-html="true"
+                        data-testid="field-help-data"
+                        data-tip="<div>
+  <p>
+    Course run dates are editable in Studio.
+  </p>
+  <p>
+    Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+  </p>
+  <p>
+    <a href='http://localhost:18010/settings/details/edX101+DemoX#schedule'
+      target='_blank'
+      rel='noopener noreferrer'>
+      Edit dates.
+    </a>
+  </p>
+</div>"
+                      />
+                      <div
+                        class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                        data-id="tooltip"
+                        id="course_runs[2].start-date-label-help-tooltip"
+                      >
+                        <style
+                          aria-hidden="true"
+                        >
+                          
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                        </style>
+                      </div>
+                    </span>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="has-value form-control"
+                    disabled=""
+                    id="course_runs[2].start-date-label"
+                    maxlength=""
+                    min=""
+                    name="course_runs[2].startDate"
+                    pattern="dd/mm/yyyy"
+                    placeholder=""
+                    type="text"
+                    value="2000/01/01"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].start-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].start-time-label"
+                  >
+                    <strong>
+                      Start time (GMT)
+                    </strong>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="has-value form-control"
+                    disabled=""
+                    id="course_runs[2].start-date-label"
+                    name="course_runs[2].startTime"
+                    placeholder="HH:mm"
+                    type="time"
+                    value="12:00"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].end-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].end-date-label"
+                  >
+                    <strong>
+                      End date
+                    </strong>
+                    <span
+                      class=""
+                      id="course_runs[2].end-date-label-help"
+                    >
+                      <button
+                        aria-describedby="course_runs[2].end-date-label-help-tooltip"
+                        aria-label="Help"
+                        class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="field-help-data"
+                        currentitem="false"
+                        data-for="course_runs[2].end-date-label-help-tooltip"
+                        data-html="true"
+                        data-testid="field-help-data"
+                        data-tip="<div>
+  <p>
+    Course run dates are editable in Studio.
+  </p>
+  <p>
+    Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+  </p>
+  <p>
+    <a href='http://localhost:18010/settings/details/edX101+DemoX#schedule'
+      target='_blank'
+      rel='noopener noreferrer'>
+      Edit dates.
+    </a>
+  </p>
+</div>"
+                      />
+                      <div
+                        class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                        data-id="tooltip"
+                        id="course_runs[2].end-date-label-help-tooltip"
+                      >
+                        <style
+                          aria-hidden="true"
+                        >
+                          
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                        </style>
+                      </div>
+                    </span>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="has-value form-control"
+                    disabled=""
+                    id="course_runs[2].end-date-label"
+                    maxlength=""
+                    min=""
+                    name="course_runs[2].endDate"
+                    pattern="dd/mm/yyyy"
+                    placeholder=""
+                    type="text"
+                    value="2010/01/01"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].end-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].end-time-label"
+                  >
+                    <strong>
+                      End time (GMT)
+                    </strong>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="has-value form-control"
+                    disabled=""
+                    id="course_runs[2].end-date-label"
+                    name="course_runs[2].endTime"
+                    placeholder="HH:mm"
+                    type="time"
+                    value="00:00"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].upgrade_deadline_override-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].upgrade_deadline_override-date-label"
+                  >
+                    <strong>
+                      Upgrade deadline override date
+                    </strong>
+                    <span
+                      class=""
+                      id="course_runs[2].upgrade_deadline_override-date-label-help"
+                    >
+                      <button
+                        aria-describedby="course_runs[2].upgrade_deadline_override-date-label-help-tooltip"
+                        aria-label="Help"
+                        class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="field-help-data"
+                        currentitem="false"
+                        data-for="course_runs[2].upgrade_deadline_override-date-label-help-tooltip"
+                        data-html="true"
+                        data-testid="field-help-data"
+                        data-tip="<div>
+  <p>
+    Course run dates are editable in Studio.
+  </p>
+  <p>
+    Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+  </p>
+  <p>
+    <a href='http://localhost:18010/settings/details/edX101+DemoX#schedule'
+      target='_blank'
+      rel='noopener noreferrer'>
+      Edit dates.
+    </a>
+  </p>
+</div>"
+                      />
+                      <div
+                        class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                        data-id="tooltip"
+                        id="course_runs[2].upgrade_deadline_override-date-label-help-tooltip"
+                      >
+                        <style
+                          aria-hidden="true"
+                        >
+                          
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                        </style>
+                      </div>
+                    </span>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="form-control"
+                    disabled=""
+                    id="course_runs[2].upgrade_deadline_override-date-label"
+                    maxlength=""
+                    min=""
+                    name="course_runs[2].upgrade_deadline_overrideDate"
+                    pattern="dd/mm/yyyy"
+                    placeholder=""
+                    type="date"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="col-6"
+            >
+              <div
+                class="pgn__form-group"
+              >
+                <label
+                  class="pgn__form-label"
+                  for="course_runs[2].upgrade_deadline_override-date-label"
+                >
+                  <div
+                    class=""
+                    id="course_runs[2].upgrade_deadline_override-time-label"
+                  >
+                    <strong>
+                      Upgrade deadline override time (UTC)
+                    </strong>
+                    <div>
+                      <span
+                        class="text-muted"
+                      />
+                    </div>
+                  </div>
+                </label>
+                <div
+                  class="pgn__form-control-decorator-group"
+                >
+                  <input
+                    class="has-value form-control"
+                    disabled=""
+                    id="course_runs[2].upgrade_deadline_override-date-label"
+                    name="course_runs[2].upgrade_deadline_overrideTime"
+                    placeholder="HH:mm"
+                    type="time"
+                    value="00:00"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr />
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].run_type-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].run_type.label"
+            >
+              <strong>
+                Course run enrollment track
+              </strong>
+              <span
+                class=""
+                id="course_runs[2].run_type.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].run_type.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].run_type.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="<div>
+  <p>
+    The enrollment track determines whether a course run offers a paid certificate and what sort of verification is required.
+  </p>
+  <p>
+    <a href='https://docs.openedx.org/en/latest/glossary.html#term-Enrollment-Track'
+      target='_blank'
+      rel='noopener noreferrer'>
+      Learn more.
+    </a>
+  </p>
+</div>"
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].run_type.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                >
+                  Cannot edit after submission
+                </span>
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <select
+              class="has-value form-control"
+              id="course_runs[2].run_type-text-label"
+              label="[object Object]"
+              name="course_runs[2].run_type"
+              required=""
+            >
+              <option
+                value=""
+              >
+                Select Course enrollment track first
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].pacing_type-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].pacing_type.label"
+            >
+              <strong>
+                Course pacing
+              </strong>
+              <span
+                class=""
+                id="course_runs[2].pacing_type.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].pacing_type.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].pacing_type.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="<div>
+  <p>
+    Course pacing is editable in Studio.
+  </p>
+  <p>
+    Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+  </p>
+  <p>
+    <a href='http://localhost:18010/settings/details/edX101+DemoX'
+      target='_blank'
+      rel='noopener noreferrer'>
+      Edit course pacing.
+    </a>
+  </p>
+</div>"
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].pacing_type.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <select
+              class="has-value form-control"
+              disabled=""
+              id="course_runs[2].pacing_type-text-label"
+              label="[object Object]"
+              name="course_runs[2].pacing_type"
+            >
+              <option
+                value="self_paced"
+              >
+                Self-paced
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].credit_provider-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].credit_provider.label"
+            >
+              <strong>
+                Credit Provider
+              </strong>
+              <span
+                class=""
+                id="course_runs[2].credit_provider.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].credit_provider.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].credit_provider.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="Enter the credit provider name if this run offers credit."
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].credit_provider.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <input
+              class="has-value form-control"
+              id="course_runs[2].credit_provider-text-label"
+              maxlength=""
+              name=""
+              placeholder=""
+              type="text"
+              value="TestProvider"
+            />
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].credit_hours-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].credit_hours.label"
+            >
+              <strong>
+                Credit Hours
+              </strong>
+              <span
+                class=""
+                id="course_runs[2].credit_hours.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].credit_hours.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].credit_hours.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="Number of credit hours offered."
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].credit_hours.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <input
+              class="has-value form-control"
+              id="course_runs[2].credit_hours-text-label"
+              maxlength=""
+              min="0"
+              name=""
+              placeholder=""
+              type="number"
+              value="3"
+            />
+          </div>
+        </div>
+        <div
+          class="row"
+        >
+          <div
+            class="col-6"
+          >
+            <div
+              class="pgn__form-group"
+            >
+              <label
+                class="pgn__form-label"
+                for="course_runs[2].upgrade_deadline-date-label"
+              >
+                <div
+                  class=""
+                  id="course_runs[2].upgrade_deadline-date-label"
+                >
+                  <strong>
+                    Upgrade Deadline
+                  </strong>
+                  <div>
+                    <span
+                      class="text-muted"
+                    />
+                  </div>
+                </div>
+              </label>
+              <div
+                class="pgn__form-control-decorator-group"
+              >
+                <input
+                  class="has-value form-control"
+                  id="course_runs[2].upgrade_deadline-date-label"
+                  maxlength=""
+                  min=""
+                  name="course_runs[2].upgrade_deadlineDate"
+                  pattern="dd/mm/yyyy"
+                  placeholder=""
+                  type="date"
+                  value="2030-01-01"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-6"
+          >
+            <div
+              class="pgn__form-group"
+            >
+              <label
+                class="pgn__form-label"
+                for="course_runs[2].upgrade_deadline-date-label"
+              >
+                <div
+                  class=""
+                  id="course_runs[2].upgrade_deadline-time-label"
+                >
+                  <strong />
+                  <div>
+                    <span
+                      class="text-muted"
+                    />
+                  </div>
+                </div>
+              </label>
+              <div
+                class="pgn__form-control-decorator-group"
+              >
+                <input
+                  class="has-value form-control"
+                  id="course_runs[2].upgrade_deadline-date-label"
+                  name="course_runs[2].upgrade_deadlineTime"
+                  placeholder="HH:mm"
+                  type="time"
+                  value="00:00"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mb-2"
+          id="course_runs[2].staff.label"
+        >
+          <strong>
+            Staff
+          </strong>
+          <span
+            aria-hidden="true"
+            class="text-gray-700"
+          >
+               (optional)
+          </span>
+          <span
+            class=""
+            id="course_runs[2].staff.label-help"
+          >
+            <button
+              aria-describedby="course_runs[2].staff.label-help-tooltip"
+              aria-label="Help"
+              class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
+              type="button"
+            >
+              <svg
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <span
+              class="field-help-data"
+              currentitem="false"
+              data-for="course_runs[2].staff.label-help-tooltip"
+              data-html="true"
+              data-testid="field-help-data"
+              data-tip="<div>
+  <p>
+    The primary instructor or instructors for the course.
+  </p>
+  <p>
+    The order that instructors are listed here is the same order they will be displayed on course pages. You can drag and drop to reorder instructors.
+  </p>
+</div>"
+            />
+            <div
+              class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+              data-id="tooltip"
+              id="course_runs[2].staff.label-help-tooltip"
+            >
+              <style
+                aria-hidden="true"
+              >
+                
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+              </style>
+            </div>
+          </span>
+          <div>
+            <span
+              class="text-muted"
+            />
+          </div>
+        </div>
+        <div
+          name="course_runs[2].staff"
+          tabindex="-1"
+        >
+          <div
+            class="staff-list container"
+            data-rbd-droppable-context-id="18"
+            data-rbd-droppable-id="staffList"
+          />
+          <label
+            class="w-100"
+            for="staff-search"
+            id="label-staff-search"
+          >
+            <strong>
+              Search or add new staff:
+            </strong>
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-owns="react-autowhatever-staff-search"
+              class="react-autosuggest__container position-relative"
+              role="combobox"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-controls="react-autowhatever-staff-search"
+                autocomplete="off"
+                class="form-control"
+                placeholder=""
+                type="text"
+                value=""
+              />
+              <div
+                id="react-autowhatever-staff-search"
+                role="listbox"
+              />
+            </div>
+          </label>
+        </div>
+        <div
+          class="row"
+        >
+          <div
+            class="col-6"
+          >
+            <div
+              class="pgn__form-group"
+            >
+              <label
+                class="pgn__form-label"
+                for="course_runs[2].min_effort-text-label"
+              >
+                <div
+                  class=""
+                  id="course_runs[2].min_effort.label"
+                >
+                  <strong>
+                    Minimum effort
+                  </strong>
+                  <span
+                    class=""
+                    id="course_runs[2].min_effort.label-help"
+                  >
+                    <button
+                      aria-describedby="course_runs[2].min_effort.label-help-tooltip"
+                      aria-label="Help"
+                      class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                      type="button"
+                    >
+                      <svg
+                        fill="none"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </button>
+                    <span
+                      class="field-help-data"
+                      currentitem="false"
+                      data-for="course_runs[2].min_effort.label-help-tooltip"
+                      data-html="true"
+                      data-testid="field-help-data"
+                      data-tip="<div>
+  <p>
+    The minimum number of hours per week the learner should expect to spend on the course.
+  </p>
+</div>"
+                    />
+                    <div
+                      class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                      data-id="tooltip"
+                      id="course_runs[2].min_effort.label-help-tooltip"
+                    >
+                      <style
+                        aria-hidden="true"
+                      >
+                        
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                      </style>
+                    </div>
+                  </span>
+                  <div>
+                    <span
+                      class="text-muted"
+                    />
+                  </div>
+                </div>
+              </label>
+              <div
+                class="pgn__form-control-decorator-group"
+              >
+                <input
+                  class="has-value form-control"
+                  id="course_runs[2].min_effort-text-label"
+                  max="168"
+                  maxlength=""
+                  min="0"
+                  name=""
+                  placeholder=""
+                  type="number"
+                  value="1"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-6"
+          >
+            <div
+              class="pgn__form-group"
+            >
+              <label
+                class="pgn__form-label"
+                for="course_runs[2].max_effort-text-label"
+              >
+                <div
+                  class=""
+                  id="course_runs[2].max_effort.label"
+                >
+                  <strong>
+                    Maximum effort
+                  </strong>
+                  <span
+                    class=""
+                    id="course_runs[2].max_effort.label-help"
+                  >
+                    <button
+                      aria-describedby="course_runs[2].max_effort.label-help-tooltip"
+                      aria-label="Help"
+                      class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                      type="button"
+                    >
+                      <svg
+                        fill="none"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </button>
+                    <span
+                      class="field-help-data"
+                      currentitem="false"
+                      data-for="course_runs[2].max_effort.label-help-tooltip"
+                      data-html="true"
+                      data-testid="field-help-data"
+                      data-tip="<div>
+  <p>
+    The maximum number of hours per week the learner should expect to spend on the course.
+  </p>
+</div>"
+                    />
+                    <div
+                      class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                      data-id="tooltip"
+                      id="course_runs[2].max_effort.label-help-tooltip"
+                    >
+                      <style
+                        aria-hidden="true"
+                      >
+                        
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                      </style>
+                    </div>
+                  </span>
+                  <div>
+                    <span
+                      class="text-muted"
+                    />
+                  </div>
+                </div>
+              </label>
+              <div
+                class="pgn__form-control-decorator-group"
+              >
+                <input
+                  class="has-value form-control"
+                  id="course_runs[2].max_effort-text-label"
+                  max="168"
+                  maxlength=""
+                  min="1"
+                  name=""
+                  placeholder=""
+                  type="number"
+                  value="1"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].weeks_to_complete-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].weeks_to_complete.label"
+            >
+              <strong>
+                Length
+              </strong>
+              <span
+                class=""
+                id="course_runs[2].weeks_to_complete.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].weeks_to_complete.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].weeks_to_complete.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="<div>
+  <p>
+    The estimated number of weeks the learner should expect to spend on the course, rounded to the nearest whole number.
+  </p>
+</div>"
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].weeks_to_complete.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <input
+              class="has-value form-control"
+              id="course_runs[2].weeks_to_complete-text-label"
+              maxlength=""
+              name=""
+              placeholder=""
+              type="number"
+              value="1"
+            />
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].content_language-text-label"
+          >
+            <div
+              class=""
+            >
+              <strong>
+                Content language
+              </strong>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <select
+              class="has-value form-control"
+              id="course_runs[2].content_language-text-label"
+              label="[object Object]"
+              name="course_runs[2].content_language"
+            >
+              <option
+                value="ar-ae"
+              >
+                Arabic - United Arab Emirates
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="mb-2"
+        >
+          <strong>
+            Transcript languages
+          </strong>
+          <div>
+            <span
+              class="text-muted"
+            />
+          </div>
+        </div>
+        <div
+          class="transcript-languages mb-3"
+          name="course_runs[2].transcript_languages"
+          tabindex="-1"
+        >
+          <ul
+            class="list-group p-0 m-0 container-fluid"
+          >
+            <li
+              class="transcript-language list-group-item row d-flex align-items-center px-0 mx-0"
+            >
+              <div
+                class="col-11"
+              >
+                <div
+                  class="pgn__form-group"
+                >
+                  <label
+                    class="pgn__form-label"
+                    for="course_runs[2].transcript_languages[0]-text-label"
+                  >
+                    <div
+                      class=""
+                    >
+                      <strong>
+                        Transcript language
+                      </strong>
+                      <div>
+                        <span
+                          class="text-muted"
+                        />
+                      </div>
+                    </div>
+                  </label>
+                  <div
+                    class="pgn__form-control-decorator-group"
+                  >
+                    <select
+                      class="has-value form-control"
+                      id="course_runs[2].transcript_languages[0]-text-label"
+                      label="[object Object]"
+                      name="course_runs[2].transcript_languages[0]"
+                      required=""
+                    >
+                      <option
+                        value="ar-ae"
+                      >
+                        Arabic - United Arab Emirates
+                      </option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+              <button
+                aria-label="Remove language"
+                class="close float-none d-flex justify-content-center align-items-center col-1"
+                data-testid="id-remove-btn"
+                title="Remove language"
+                type="button"
+              >
+                <svg
+                  fill="none"
+                  height="24"
+                  id="remove-field"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </li>
+          </ul>
+          <button
+            class="btn btn-outline-primary js-add-button mt-2"
+            data-testid="test-js-add-btn"
+            type="button"
+          >
+            Add language
+          </button>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].expected_program_type-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].expected_program_type.label"
+            >
+              <strong>
+                Expected Program Type
+              </strong>
+              <span
+                aria-hidden="true"
+                class="text-gray-700"
+              >
+                   (optional)
+              </span>
+              <span
+                class=""
+                id="course_runs[2].expected_program_type.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].expected_program_type.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].expected_program_type.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="<div>
+  <p>
+    If this Course Run will potentially be part of a Program, please set the expected program type here.
+  </p>
+</div>"
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].expected_program_type.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <select
+              class="form-control"
+              id="course_runs[2].expected_program_type-text-label"
+              label="[object Object]"
+              name="course_runs[2].expected_program_type"
+            >
+              <option
+                value=""
+              >
+                --
+              </option>
+              <option
+                value="professional-certificate"
+              >
+                Professional Certificate
+              </option>
+              <option
+                value="micromasters"
+              >
+                MicroMasters
+              </option>
+              <option
+                value="xseries"
+              >
+                XSeries
+              </option>
+              <option
+                value="masters"
+              >
+                Masters
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="pgn__form-group"
+        >
+          <label
+            class="pgn__form-label"
+            for="course_runs[2].expected_program_name-text-label"
+          >
+            <div
+              class=""
+              id="course_runs[2].expected_program_name.label"
+            >
+              <strong>
+                Expected Program Name
+              </strong>
+              <span
+                aria-hidden="true"
+                class="text-gray-700"
+              >
+                   (optional)
+              </span>
+              <span
+                class=""
+                id="course_runs[2].expected_program_name.label-help"
+              >
+                <button
+                  aria-describedby="course_runs[2].expected_program_name.label-help-tooltip"
+                  aria-label="Help"
+                  class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  class="field-help-data"
+                  currentitem="false"
+                  data-for="course_runs[2].expected_program_name.label-help-tooltip"
+                  data-html="true"
+                  data-testid="field-help-data"
+                  data-tip="<div>
+  <p>
+    If this Course Run will potentially be part of a Program, please set the expected program name here.
+  </p>
+</div>"
+                />
+                <div
+                  class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                  data-id="tooltip"
+                  id="course_runs[2].expected_program_name.label-help-tooltip"
+                >
+                  <style
+                    aria-hidden="true"
+                  >
+                    
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                  </style>
+                </div>
+              </span>
+              <div>
+                <span
+                  class="text-muted"
+                />
+              </div>
+            </div>
+          </label>
+          <div
+            class="pgn__form-control-decorator-group"
+          >
+            <input
+              class="form-control"
+              id="course_runs[2].expected_program_name-text-label"
+              maxlength=""
+              name=""
+              placeholder=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div>
+          <div
+            class="mb-2"
+            id="ofac-notice-label"
+          >
+            <strong>
+              Course Embargo (OFAC) Restriction text added to the FAQ section
+            </strong>
+            <span
+              class=""
+              id="ofac-notice-label-help"
+            >
+              <button
+                aria-describedby="ofac-notice-label-help-tooltip"
+                aria-label="Help"
+                class="btn btn-link py-0 px-0 mx-1 align-bottom "
+                type="button"
+              >
+                <svg
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+              <span
+                class="field-help-data"
+                currentitem="false"
+                data-for="ofac-notice-label-help-tooltip"
+                data-html="true"
+                data-testid="field-help-data"
+                data-tip="<div>
+  <p>
+    Course embargo status for OFAC is managed internally, please contact support with questions.
+  </p>
+</div>"
+              />
+              <div
+                class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-right type-dark allow_click"
+                data-id="tooltip"
+                id="ofac-notice-label-help-tooltip"
+              >
+                <style
+                  aria-hidden="true"
+                >
+                  
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+	    border-radius: undefinedpx;
+	    padding: 8px 21px;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: 2;
+        width: 20px;
+        height: 12px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(135deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 18px;
+        height: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        top: -6px;
+        left: 50%;
+        margin-left: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        right: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(45deg);
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        content: "";
+        background-color: inherit;
+        position: absolute;
+        z-index: -1;
+        width: 10px;
+        height: 18px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        content: "";
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        border-top-right-radius: undefinedpx;
+        border: 1px solid transparent;
+        background-color: #222;
+        z-index: -2;
+        left: -6px;
+        top: 50%;
+        margin-top: -6px;
+        transform: rotate(-135deg);
+    }
+  
+                </style>
+              </div>
+            </span>
+            <div>
+              <span
+                class="text-muted"
+              />
+            </div>
+          </div>
+          <div
+            class="mb-3"
+          >
+            No
+          </div>
+        </div>
+        <div
+          class="btn-toolbar justify-content-end"
+          role="toolbar"
+        >
+          <div
+            class="btn-group ml-2"
+            role="group"
+          >
+            <button
+              aria-disabled="false"
+              aria-live="assertive"
+              class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+              type="submit"
+            >
+              <span
+                class="d-flex align-items-center justify-content-center"
+              >
+                <span>
+                  Submit Run for Review
+                </span>
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -95,6 +95,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -325,6 +326,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -557,6 +559,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -803,6 +806,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -1050,6 +1054,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1320,6 +1325,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -1546,6 +1552,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1771,6 +1778,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -2028,6 +2036,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2644,6 +2653,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2866,6 +2876,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -3096,6 +3107,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3338,6 +3350,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3562,6 +3575,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3781,6 +3795,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3999,6 +4014,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4229,6 +4245,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4781,6 +4798,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -5011,6 +5029,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -5239,6 +5258,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -5485,6 +5505,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -5732,6 +5753,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6002,6 +6024,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -6228,6 +6251,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -6453,6 +6477,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -6710,6 +6735,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -7326,6 +7352,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -7548,6 +7575,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -7778,6 +7806,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -8020,6 +8049,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -8244,6 +8274,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -8463,6 +8494,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -8681,6 +8713,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8911,6 +8944,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -9463,6 +9497,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -9693,6 +9728,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -9921,6 +9957,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -10167,6 +10204,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -10414,6 +10452,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -10645,6 +10684,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -10871,6 +10911,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -11096,6 +11137,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -11351,6 +11393,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -11580,6 +11623,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -12131,6 +12175,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -12361,6 +12406,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -12589,6 +12635,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -12835,6 +12882,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -13082,6 +13130,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -13351,6 +13400,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -13577,6 +13627,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -13802,6 +13853,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -14059,6 +14111,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -14675,6 +14728,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -14897,6 +14951,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -15127,6 +15182,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -15369,6 +15425,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -15593,6 +15650,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -15812,6 +15870,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -16030,6 +16089,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -16259,6 +16319,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -16810,6 +16871,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -17040,6 +17102,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -17268,6 +17331,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -17514,6 +17578,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -17761,6 +17826,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -18030,6 +18096,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -18256,6 +18323,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -18481,6 +18549,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -18738,6 +18807,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -19354,6 +19424,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -19576,6 +19647,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -19806,6 +19878,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -20048,6 +20121,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -20272,6 +20346,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -20491,6 +20566,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -20716,6 +20792,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="additional-info.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -20915,6 +20992,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="video.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -21153,6 +21231,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -21382,6 +21461,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -22127,6 +22207,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="geolocation.info-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -22305,6 +22386,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationName.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -22499,6 +22581,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationLng.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -22695,6 +22778,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationLat.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -23010,6 +23094,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23240,6 +23325,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -23468,6 +23554,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -23714,6 +23801,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -23961,6 +24049,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -24230,6 +24319,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -24456,6 +24546,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -24681,6 +24772,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -24938,6 +25030,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -25554,6 +25647,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -25776,6 +25870,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -26006,6 +26101,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26248,6 +26344,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26472,6 +26569,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26691,6 +26789,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26909,6 +27008,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -27138,6 +27238,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -27689,6 +27790,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -27919,6 +28021,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -28147,6 +28250,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -28393,6 +28497,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -28640,6 +28745,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -28871,6 +28977,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -29097,6 +29204,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -29322,6 +29430,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -29577,6 +29686,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -29806,6 +29916,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -30357,6 +30468,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -30587,6 +30699,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -30815,6 +30928,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -31061,6 +31175,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -31308,6 +31423,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -31539,6 +31655,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -31765,6 +31882,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -31990,6 +32108,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -32245,6 +32364,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -32474,6 +32594,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -32830,6 +32951,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="skills.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -95,6 +95,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -325,6 +326,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -557,6 +559,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -803,6 +806,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -1050,6 +1054,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -1320,6 +1325,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -1546,6 +1552,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -1771,6 +1778,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -2028,6 +2036,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2251,6 +2260,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2469,6 +2479,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -2695,6 +2706,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -2933,6 +2945,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3153,6 +3166,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3368,6 +3382,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -3582,6 +3597,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -3812,6 +3828,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4364,6 +4381,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -4594,6 +4612,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -4822,6 +4841,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -5068,6 +5088,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -5315,6 +5336,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -5585,6 +5607,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -5811,6 +5834,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -6036,6 +6060,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -6293,6 +6318,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6516,6 +6542,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6734,6 +6761,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -6960,6 +6988,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -7198,6 +7227,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -7418,6 +7448,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -7633,6 +7664,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -7847,6 +7879,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8077,6 +8110,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8629,6 +8663,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -8859,6 +8894,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -9087,6 +9123,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -9333,6 +9370,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -9580,6 +9618,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -9811,6 +9850,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -10037,6 +10077,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -10262,6 +10303,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -10517,6 +10559,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -10746,6 +10789,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -11297,6 +11341,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -11527,6 +11572,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -11755,6 +11801,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -12001,6 +12048,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -12248,6 +12296,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -12517,6 +12566,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -12743,6 +12793,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -12968,6 +13019,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -13225,6 +13277,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -13448,6 +13501,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -13666,6 +13720,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -13892,6 +13947,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -14130,6 +14186,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -14350,6 +14407,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -14565,6 +14623,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -14779,6 +14838,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -15008,6 +15068,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -15559,6 +15620,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -15789,6 +15851,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -16017,6 +16080,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -16263,6 +16327,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -16510,6 +16575,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -16779,6 +16845,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -17005,6 +17072,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -17230,6 +17298,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -17487,6 +17556,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -17710,6 +17780,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -17928,6 +17999,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -18154,6 +18226,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -18392,6 +18465,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -18612,6 +18686,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -18827,6 +18902,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -19048,6 +19124,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="additional-info.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -19243,6 +19320,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="video.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -19481,6 +19559,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -19710,6 +19789,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -20455,6 +20535,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                   >
                     <button
                       aria-describedby="geolocation.info-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -20633,6 +20714,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationName.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -20827,6 +20909,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationLng.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -21023,6 +21106,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       >
                         <button
                           aria-describedby="geoLocationLat.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -21338,6 +21422,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -21568,6 +21653,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -21796,6 +21882,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -22042,6 +22129,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -22289,6 +22377,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -22558,6 +22647,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -22784,6 +22874,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -23009,6 +23100,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -23266,6 +23358,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="sdesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23489,6 +23582,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="ldesc.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23707,6 +23801,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="outcome.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -23933,6 +24028,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="syllabus.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -24171,6 +24267,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="prereq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -24391,6 +24488,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="testimonials.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -24606,6 +24704,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="faq.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -24820,6 +24919,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -25049,6 +25149,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -25600,6 +25701,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -25830,6 +25932,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26058,6 +26161,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -26304,6 +26408,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -26551,6 +26656,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -26782,6 +26888,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -27008,6 +27115,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -27233,6 +27341,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -27488,6 +27597,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -27717,6 +27827,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -28268,6 +28379,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="title.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -28498,6 +28610,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="slug.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -28726,6 +28839,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="watchers.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -28972,6 +29086,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                 >
                   <button
                     aria-describedby="productSource-help-tooltip"
+                    aria-label="Help"
                     class="btn btn-link py-0 px-0 mx-1 align-bottom "
                     type="button"
                   >
@@ -29219,6 +29334,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="type.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -29450,6 +29566,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
               >
                 <button
                   aria-describedby="collaborators.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                   type="button"
                 >
@@ -29676,6 +29793,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                     >
                       <button
                         aria-describedby="image.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom "
                         type="button"
                       >
@@ -29901,6 +30019,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="tags.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                       type="button"
                     >
@@ -30156,6 +30275,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="level.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -30385,6 +30505,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="subject1.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -30741,6 +30862,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                   >
                     <button
                       aria-describedby="skills.label-help-tooltip"
+                      aria-label="Help"
                       class="btn btn-link py-0 px-0 mx-1 align-bottom "
                       type="button"
                     >
@@ -31150,6 +31272,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -31379,6 +31502,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -31607,6 +31731,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -31853,6 +31978,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -32100,6 +32226,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -32331,6 +32458,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -32556,6 +32684,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -32780,6 +32909,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -33035,6 +33165,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -33263,6 +33394,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -34029,6 +34161,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -34258,6 +34391,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -34486,6 +34620,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -34732,6 +34867,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -34979,6 +35115,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -35210,6 +35347,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -35435,6 +35573,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -35659,6 +35798,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -35914,6 +36054,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -36142,6 +36283,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -36871,6 +37013,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -37100,6 +37243,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -37328,6 +37472,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -37574,6 +37719,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -37821,6 +37967,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -38052,6 +38199,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -38277,6 +38425,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -38501,6 +38650,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -38756,6 +38906,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -38984,6 +39135,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -39713,6 +39865,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -39942,6 +40095,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -40170,6 +40324,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -40416,6 +40571,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -40663,6 +40819,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -40894,6 +41051,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -41119,6 +41277,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -41343,6 +41502,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -41598,6 +41758,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -41826,6 +41987,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -42571,6 +42733,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -42800,6 +42963,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -43028,6 +43192,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -43274,6 +43439,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -43521,6 +43687,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -43752,6 +43919,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -43977,6 +44145,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -44201,6 +44370,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -44456,6 +44626,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -44684,6 +44855,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -45413,6 +45585,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -45642,6 +45815,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -45870,6 +46044,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -46116,6 +46291,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -46363,6 +46539,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -46594,6 +46771,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -46819,6 +46997,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -47043,6 +47222,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -47298,6 +47478,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -47526,6 +47707,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -48304,6 +48486,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -48533,6 +48716,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -48761,6 +48945,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -49007,6 +49192,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -49254,6 +49440,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -49485,6 +49672,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -49710,6 +49898,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -49934,6 +50123,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -50189,6 +50379,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -50417,6 +50608,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -51146,6 +51338,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -51375,6 +51568,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -51603,6 +51797,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -51849,6 +52044,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -52096,6 +52292,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -52327,6 +52524,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -52552,6 +52750,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -52776,6 +52975,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -53031,6 +53231,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -53259,6 +53460,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -53988,6 +54190,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="title.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -54217,6 +54420,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="slug.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -54445,6 +54649,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="watchers.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -54691,6 +54896,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                       >
                         <button
                           aria-describedby="productSource-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -54938,6 +55144,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="type.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -55169,6 +55376,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                     >
                       <button
                         aria-describedby="collaborators.label-help-tooltip"
+                        aria-label="Help"
                         class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                         type="button"
                       >
@@ -55394,6 +55602,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                           >
                             <button
                               aria-describedby="image.label-help-tooltip"
+                              aria-label="Help"
                               class="btn btn-link py-0 px-0 mx-1 align-bottom "
                               type="button"
                             >
@@ -55618,6 +55827,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="tags.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom text-gray-700"
                             type="button"
                           >
@@ -55873,6 +56083,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="level.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -56101,6 +56312,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                         >
                           <button
                             aria-describedby="subject1.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -186,7 +186,7 @@ class EditCoursePage extends React.Component {
         draft = false;
       }
 
-      sendCourseRuns.push({
+      const runPayload = {
         content_language: courseRun.content_language,
         draft,
         expected_program_type: courseRun.expected_program_type
@@ -221,7 +221,28 @@ class EditCoursePage extends React.Component {
           ? courseRun.weeks_to_complete
           : null,
         restriction_type: courseRun.restriction_type,
-      });
+      };
+
+      if (courseRun.credit_provider && courseRun.credit_provider.trim() !== '') {
+        runPayload.credit_provider = courseRun.credit_provider.trim();
+      }
+
+      if (
+        courseRun.credit_hours !== undefined
+        && courseRun.credit_hours !== null
+        && courseRun.credit_hours !== ''
+      ) {
+        const parsed = Number(courseRun.credit_hours);
+        if (!Number.isNaN(parsed)) {
+          runPayload.credit_hours = parsed;
+        }
+      }
+
+      if (isValidDate(courseRun.upgrade_deadline)) {
+        runPayload.upgrade_deadline = courseRun.upgrade_deadline;
+      }
+
+      sendCourseRuns.push(runPayload);
     });
     return sendCourseRuns;
   }
@@ -529,6 +550,7 @@ class EditCoursePage extends React.Component {
         bulk_sku: seat.bulk_sku,
         credit_hours: seat.credit_hours,
         credit_provider: seat.credit_provider,
+        upgrade_deadline: seat.upgrade_deadline,
         currency: seat.currency,
         price: seat.price,
         sku: seat.sku,
@@ -1020,6 +1042,9 @@ EditCoursePage.propTypes = {
       key: PropTypes.string,
       uuid: PropTypes.string,
       status: PropTypes.string,
+      credit_provider: PropTypes.string,
+      credit_hours: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      upgrade_deadline: PropTypes.string,
     }),
   }),
   formValues: PropTypes.func,

--- a/src/components/FieldHelp/FieldHelp.test.jsx
+++ b/src/components/FieldHelp/FieldHelp.test.jsx
@@ -3,6 +3,7 @@ import ReactTooltip from 'react-tooltip';
 import {
   fireEvent, waitFor, render, screen,
 } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import FieldHelp from './index';
 
 jest.mock('react-tooltip');
@@ -24,5 +25,43 @@ describe('FieldHelp', () => {
     const fieldHelpData = screen.getByTestId('field-help-data');
     const dataTip = fieldHelpData.getAttribute('data-tip');
     expect(dataTip).toMatch(/<p>\s*Hello World\s*<\/p>/);
+  });
+
+  it('renders correctly when tip is a string', () => {
+    render(<FieldHelp id="string-tip" tip="Simple text tip" />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    const fieldHelpData = screen.getByTestId('field-help-data');
+    expect(fieldHelpData.getAttribute('data-tip')).toContain('Simple text tip');
+  });
+
+  it('renders correctly when tip is a number', () => {
+    render(<FieldHelp id="number-tip" tip={12345} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    const fieldHelpData = screen.getByTestId('field-help-data');
+    expect(fieldHelpData.getAttribute('data-tip')).toContain('12345');
+  });
+
+  it('renders empty data-tip when no tip provided', () => {
+    render(<FieldHelp id="no-tip" />);
+    const fieldHelpData = screen.getByTestId('field-help-data');
+    expect(fieldHelpData.getAttribute('data-tip')).toBe('');
+  });
+
+  it('handles jsxToString throwing an error gracefully', async () => {
+    jest.resetModules();
+    jest.doMock('jsx-to-string', () => () => {
+      throw new Error('Conversion failed');
+    });
+
+    const { default: FaultyFieldHelp } = await import('./index');
+
+    const { getByTestId } = render(
+      <FaultyFieldHelp id="error-case" tip={<div><span>Invalid JSX</span></div>} />,
+    );
+
+    const fieldHelpData = getByTestId('field-help-data');
+    expect(fieldHelpData.getAttribute('data-tip')).toBe('');
   });
 });

--- a/src/components/FieldHelp/index.jsx
+++ b/src/components/FieldHelp/index.jsx
@@ -5,6 +5,20 @@ import { InfoOutline } from '@openedx/paragon/icons';
 import jsxToString from 'jsx-to-string';
 import ReactTooltip from 'react-tooltip';
 
+function safeJsxToString(tip) {
+  if (tip === null || tip === undefined) {
+    return '';
+  }
+  if (typeof tip === 'string' || typeof tip === 'number') {
+    return String(tip);
+  }
+  try {
+    return jsxToString(tip);
+  } catch (err) {
+    return '';
+  }
+}
+
 class FieldHelp extends React.Component {
   constructor(props) {
     super(props);
@@ -49,6 +63,7 @@ class FieldHelp extends React.Component {
       <span id={this.props.id} className={this.props.className}>
         <button
           type="button"
+          aria-label="Help"
           className={`btn btn-link py-0 px-0 mx-1 align-bottom ${this.props.optional ? 'text-gray-700' : ''}`}
           onClick={this.toggleToolTip}
           onBlur={this.closeToolTip}
@@ -60,7 +75,7 @@ class FieldHelp extends React.Component {
           className="field-help-data"
           data-testid="field-help-data"
           ref={this.setTip}
-          data-tip={jsxToString(this.props.tip)}
+          data-tip={safeJsxToString(this.props.tip)}
           data-html
           data-for={`${this.props.id}-tooltip`}
         />

--- a/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
               >
                 <button
                   aria-describedby="image.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -302,6 +303,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
             >
               <button
                 aria-describedby="title.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -1189,6 +1191,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
               >
                 <button
                   aria-describedby="image.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -1461,6 +1464,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
             >
               <button
                 aria-describedby="title.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -2348,6 +2352,7 @@ exports[`StafferForm renders html correctly 1`] = `
               >
                 <button
                   aria-describedby="image.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -2620,6 +2625,7 @@ exports[`StafferForm renders html correctly 1`] = `
             >
               <button
                 aria-describedby="title.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -3507,6 +3513,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
               >
                 <button
                   aria-describedby="image.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -3779,6 +3786,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
             >
               <button
                 aria-describedby="title.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >
@@ -4689,6 +4697,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
               >
                 <button
                   aria-describedby="image.label-help-tooltip"
+                  aria-label="Help"
                   class="btn btn-link py-0 px-0 mx-1 align-bottom "
                   type="button"
                 >
@@ -4961,6 +4970,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
             >
               <button
                 aria-describedby="title.label-help-tooltip"
+                aria-label="Help"
                 class="btn btn-link py-0 px-0 mx-1 align-bottom "
                 type="button"
               >

--- a/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
@@ -47,6 +47,7 @@ exports[`StafferPage renders html correctly 1`] = `
                         >
                           <button
                             aria-describedby="image.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -319,6 +320,7 @@ exports[`StafferPage renders html correctly 1`] = `
                       >
                         <button
                           aria-describedby="title.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -1256,6 +1258,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                         >
                           <button
                             aria-describedby="image.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -1528,6 +1531,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                       >
                         <button
                           aria-describedby="title.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -2437,6 +2441,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                         >
                           <button
                             aria-describedby="image.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -2709,6 +2714,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                       >
                         <button
                           aria-describedby="title.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >
@@ -3708,6 +3714,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                         >
                           <button
                             aria-describedby="image.label-help-tooltip"
+                            aria-label="Help"
                             class="btn btn-link py-0 px-0 mx-1 align-bottom "
                             type="button"
                           >
@@ -3980,6 +3987,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                       >
                         <button
                           aria-describedby="title.label-help-tooltip"
+                          aria-label="Help"
                           class="btn btn-link py-0 px-0 mx-1 align-bottom "
                           type="button"
                         >


### PR DESCRIPTION
This PR adds UI support in frontend-app-publisher to manage credit seat metadata for course runs — including credit provider, credit hours, and upgrade deadline.

Verified credit fields appear only for credit-type seats and send correct payloads.

Related Ticket - https://2u-internal.atlassian.net/browse/PROD-4432